### PR TITLE
Ensure we are using the Builder from the project's version of ember-cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
         var outputPath = this.readConfig('outputPath');
         var buildEnv   = this.readConfig('environment');
 
-        var Builder  = require('ember-cli/lib/models/builder');
+        var Builder  = this.project.require('ember-cli/lib/models/builder');
         var builder = new Builder({
           ui: this.ui,
           outputPath: outputPath,

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -111,7 +111,12 @@ describe('build plugin', function() {
 
       context = {
         ui: mockUi,
-        project: { name: function() { return 'test-project'; }, addons: [], root: 'tests/dummy' },
+        project: {
+          name: function() { return 'test-project'; },
+          require: function(mod) { return require(mod); },
+          addons: [],
+          root: 'tests/dummy'
+        },
         config: {
           build: {
             buildEnv: 'development',


### PR DESCRIPTION
In an `npm link` situation, the way we were requiring builder would load the builder
from the devDepencies of this plugin, which can be a problem if it is not the same
as the project's version.

Fixes #13